### PR TITLE
Adds networkStart and networkClean scripts

### DIFF
--- a/networkClean
+++ b/networkClean
@@ -1,0 +1,2 @@
+sudo killall controller
+sudo mn -c

--- a/networkStart
+++ b/networkStart
@@ -1,0 +1,2 @@
+xterm -e "sudo mn --topo single,3 --mac --switch ovsk --controller remote -x" &
+./pox.py log.level --DEBUG misc.of_tutorial &


### PR DESCRIPTION
networkStart is used to automatically start the network in the required format. It opens mininet in a new terminal and creates a network with 3 hosts and 1 switch. Xterms are spawned for all three hosts, the switch and the controller. It then executes pox.py in the background to enable the hub fucntionality.

networkClean can be run after mininet is closed to ensure everything has closed out correctly and prepares the network for future runs. It terminates any controller process that is still running and cleans mininet.

Place both scripts in the 'pox' directory and give them execute permissions to use